### PR TITLE
Add Clear Statuses feature with enhanced bulk actions

### DIFF
--- a/frontend/src/components/BulkActionBar.tsx
+++ b/frontend/src/components/BulkActionBar.tsx
@@ -20,6 +20,7 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ClearIcon from '@mui/icons-material/Clear';
 import { useSelection } from '../contexts/SelectionContext';
 import { ICollection } from '../utils/jam-api';
 
@@ -29,6 +30,7 @@ interface BulkActionBarProps {
   onBulkAdd: (targetCollectionId: string, companyIds: number[]) => void;
   onBulkRemove: (companyIds: number[]) => void;
   onSelectAll: () => void;
+  onClearStatuses?: (companyIds: number[]) => void;
   isLoading?: boolean;
 }
 
@@ -38,6 +40,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
   onBulkAdd,
   onBulkRemove,
   onSelectAll,
+  onClearStatuses,
   isLoading = false,
 }) => {
   const {
@@ -70,6 +73,13 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
     const ids = getSelectedIds();
     onBulkRemove(ids);
   }, [getSelectedIds, onBulkRemove]);
+  
+  const handleClearStatuses = useCallback(() => {
+    const ids = getSelectedIds();
+    if (onClearStatuses) {
+      onClearStatuses(ids);
+    }
+  }, [getSelectedIds, onClearStatuses]);
 
   // Get available target collections (exclude current)
   const targetCollections = collections.filter(c => c.id !== currentCollectionId);
@@ -142,7 +152,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         {isLoading && <CircularProgress size={20} sx={{ color: '#1a73e8' }} />}
         
-        {/* My List: Like, Ignore, Delete */}
+        {/* My List: Like, Ignore, Clear Statuses, Delete */}
         {isMyList && (
           <>
             <Button
@@ -179,6 +189,25 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
               }}
             >
               Ignore
+            </Button>
+            
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<ClearIcon />}
+              onClick={handleClearStatuses}
+              disabled={isLoading || !onClearStatuses}
+              sx={{
+                textTransform: 'none',
+                borderColor: '#1a73e8',
+                color: '#1a73e8',
+                '&:hover': {
+                  bgcolor: 'rgba(26, 115, 232, 0.04)',
+                  borderColor: '#1a73e8',
+                },
+              }}
+            >
+              Clear Statuses
             </Button>
           </>
         )}

--- a/frontend/src/components/ClearStatusesDialog.tsx
+++ b/frontend/src/components/ClearStatusesDialog.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Alert,
+  Divider,
+} from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import ClearIcon from '@mui/icons-material/Clear';
+
+interface ClearStatusesDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  totalSelected: number;
+  likedCount: number;
+  ignoredCount: number;
+  noStatusCount: number;
+}
+
+const ClearStatusesDialog: React.FC<ClearStatusesDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  totalSelected,
+  likedCount,
+  ignoredCount,
+  noStatusCount,
+}) => {
+  const totalAffected = likedCount + ignoredCount;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+          boxShadow: '0 8px 16px rgba(0,0,0,0.1)',
+        },
+      }}
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, color: '#202124' }}>
+          Review Before Clearing Statuses
+        </Typography>
+        <Typography variant="body2" sx={{ color: '#5f6368', mt: 0.5 }}>
+          Clearing statuses for {totalSelected.toLocaleString()} companies
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 2 }}>
+        {/* Summary Stats */}
+        <Box sx={{ display: 'flex', gap: 3, mb: 3 }}>
+          {totalAffected > 0 && (
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h4" sx={{ fontWeight: 600, color: '#1a73e8' }}>
+                {totalAffected.toLocaleString()}
+              </Typography>
+              <Typography variant="body2" sx={{ color: '#5f6368' }}>
+                will be cleared
+              </Typography>
+            </Box>
+          )}
+          {noStatusCount > 0 && (
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h4" sx={{ fontWeight: 600, color: '#5f6368' }}>
+                {noStatusCount.toLocaleString()}
+              </Typography>
+              <Typography variant="body2" sx={{ color: '#5f6368' }}>
+                no changes
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Breakdown by status */}
+        {likedCount > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+              <FavoriteIcon sx={{ color: '#ea4335', fontSize: 20 }} />
+              <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                {likedCount.toLocaleString()} companies in Liked List
+              </Typography>
+            </Box>
+            <Typography variant="body2" sx={{ color: '#5f6368', ml: 3.5 }}>
+              Will be removed from Liked List
+            </Typography>
+          </Box>
+        )}
+
+        {ignoredCount > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+              <VisibilityOffIcon sx={{ color: '#5f6368', fontSize: 20 }} />
+              <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                {ignoredCount.toLocaleString()} companies in Ignore List
+              </Typography>
+            </Box>
+            <Typography variant="body2" sx={{ color: '#5f6368', ml: 3.5 }}>
+              Will be removed from Ignore List
+            </Typography>
+          </Box>
+        )}
+
+        {/* Info alert */}
+        {totalAffected > 0 ? (
+          <Alert severity="info" sx={{ mt: 3 }}>
+            {totalAffected.toLocaleString()} companies will have their liked/ignored statuses cleared.
+            {noStatusCount > 0 && ` ${noStatusCount.toLocaleString()} companies have no status and won't be affected.`}
+          </Alert>
+        ) : (
+          <Alert severity="info" sx={{ mt: 3 }}>
+            No companies in your selection have liked or ignored statuses. Nothing to clear.
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          variant="contained"
+          disabled={totalAffected === 0}
+          startIcon={<ClearIcon />}
+          sx={{
+            bgcolor: '#1a73e8',
+            '&:hover': {
+              bgcolor: '#1967d2',
+            },
+          }}
+        >
+          Clear {totalAffected > 0 ? totalAffected.toLocaleString() : ''} Statuses
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ClearStatusesDialog;

--- a/frontend/src/utils/jam-api.ts
+++ b/frontend/src/utils/jam-api.ts
@@ -150,3 +150,25 @@ export async function checkConflicts(request: IConflictCheckRequest): Promise<IC
         throw error;
     }
 }
+
+export interface IStatusCheckRequest {
+    company_ids: number[];
+}
+
+export interface IStatusCheckResponse {
+    liked_count: number;
+    ignored_count: number;
+    no_status_count: number;
+    liked_ids: number[];
+    ignored_ids: number[];
+}
+
+export async function checkStatuses(request: IStatusCheckRequest): Promise<IStatusCheckResponse> {
+    try {
+        const response = await axios.post(`${BASE_URL}/companies/check-statuses`, request);
+        return response.data;
+    } catch (error) {
+        console.error('Error checking statuses:', error);
+        throw error;
+    }
+}


### PR DESCRIPTION
- Add Clear Statuses button to My List page bulk action bar
- Create status check API endpoint to determine affected companies
- Implement ClearStatusesDialog matching ConflictResolutionDialog design
- Show detailed breakdown of companies by status (liked/ignored/none)
- Only process companies that actually have statuses
- Add confirmation dialog with count breakdown before clearing
- Context-specific bulk action buttons for each collection:
  - My List: Like, Ignore, Clear Statuses, Delete
  - Liked List: Unlike, Ignore, Delete
  - Ignore List: Unignore, Like, Delete